### PR TITLE
Fix mismatched contact phone link and remove redundant script

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,7 +94,7 @@
 <!-- Kapcsolat -->
 <section class="bg-cyan-600 text-white text-center p-8 rounded-3xl shadow-xl space-y-3">
 <h2 class="text-3xl font-bold mb-6">Kapcsolat</h2>
-<p>📞 Telefon: <a class="underline font-semibold" href="tel:+36201234567">+36 20 220 2499</a></p>
+<p>📞 Telefon: <a class="underline font-semibold" href="tel:+36202202499">+36 20 220 2499</a></p>
 <p>📧 E-mail: <a class="underline font-semibold" href="mailto:gdleptech@gmail.com">gdleptech@gmail.com</a></p>
 <p>📍 Szolgáltatási terület: Gödöllő, Budapest és környéke</p>
 </section>
@@ -121,16 +121,6 @@ document.querySelectorAll('[id$="Modal"]').forEach(modal => {
     }
   });
 });
-</script>
-<script>
-  // Kattintás a modálon kívül: zárás
-  document.querySelectorAll('[id$="Modal"]').forEach(function(modal){
-    modal.addEventListener('click', function(e){
-      if (e.target === modal) {
-        modal.classList.add('hidden');
-      }
-    });
-  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Correct phone link so it matches the displayed number
- Remove duplicated modal-closing script to avoid redundant event listeners

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689df90389888329826d25bfc96af75e